### PR TITLE
CVF-4, CVF-5: remove useless conditional statement

### DIFF
--- a/src/RuleWhiteList.sol
+++ b/src/RuleWhiteList.sol
@@ -74,10 +74,8 @@ contract RuleWhitelist is IRule, CodeList, AccessControl {
             !whitelist[_newWhitelistAddress],
             "Address is already in the whitelist"
         );
-        if (!whitelist[_newWhitelistAddress]) {
-            whitelist[_newWhitelistAddress] = true;
-            ++numAddressesWhitelisted;
-        }
+        whitelist[_newWhitelistAddress] = true;
+        ++numAddressesWhitelisted;
     }
 
     /**
@@ -92,10 +90,8 @@ contract RuleWhitelist is IRule, CodeList, AccessControl {
             whitelist[_removeWhitelistAddress],
             "Address is not in the whitelist"
         );
-        if (whitelist[_removeWhitelistAddress]) {
-            whitelist[_removeWhitelistAddress] = false;
-            --numAddressesWhitelisted;
-        }
+        whitelist[_removeWhitelistAddress] = false;
+        --numAddressesWhitelisted;
     }
 
     /**


### PR DESCRIPTION
**CVF-4 & CVF-5**

> This condition is always true due to the "require" statement above.
> Consider removing the conditional statement.

Fix: 
The conditional statement has been removed as recommended