### PR TITLE
CVF-7, CVF-8, CVF-9: check for duplicate rule

### DIFF
--- a/src/RuleEngine.sol
+++ b/src/RuleEngine.sol
@@ -12,6 +12,7 @@ import "../lib/openzeppelin-contracts/contracts/access/AccessControl.sol";
 */
 contract RuleEngine is IRuleEngine, AccessControl {
     bytes32 public constant RULE_ENGINE_ROLE = keccak256("RULE_ENGINE_ROLE");
+    mapping(IRule => bool) ruleIsPresent;
     IRule[] internal _rules;
 
     constructor() {
@@ -32,6 +33,8 @@ contract RuleEngine is IRuleEngine, AccessControl {
                 address(rules_[i]) != address(0x0),
                 "One of the rules is a zero address"
             );
+            require(!ruleIsPresent[rules_[i]], "The rule is already present");
+            ruleIsPresent[rules_[i]] = true;
             unchecked {
                 ++i;
             }
@@ -57,7 +60,9 @@ contract RuleEngine is IRuleEngine, AccessControl {
             address(rule_) != address(0x0),
             "The rule can't be a zero address"
         );
+        require(!ruleIsPresent[rule_], "The rule is already present");
         _rules.push(rule_);
+        ruleIsPresent[rule_] = true;
     }
 
     /**
@@ -74,6 +79,7 @@ contract RuleEngine is IRuleEngine, AccessControl {
                     _rules[i] = _rules[_rules.length - 1];
                 }
                 _rules.pop();
+                ruleIsPresent[rule_] = false;
                 break;
             }
             unchecked {

--- a/test/RuleEngine/RuleEngine.t.sol
+++ b/test/RuleEngine/RuleEngine.t.sol
@@ -52,6 +52,30 @@ contract RuleEngineTest is Test, HelperContract, RuleWhitelist {
         assertEq(resUint256, 2);
     }
 
+    function testCannotSetRuleIfARuleIsAlreadyPresent() public {
+        // Arrange
+        vm.prank(WHITELIST_OPERATOR_ADDRESS);
+        RuleWhitelist ruleWhitelist1 = new RuleWhitelist();
+        IRule[] memory ruleWhitelistTab = new IRule[](2);
+        ruleWhitelistTab[0] = IRule(ruleWhitelist1);
+        ruleWhitelistTab[1] = IRule(ruleWhitelist1);
+
+        // Act
+        vm.prank(RULE_ENGINE_OPERATOR_ADDRESS);
+        vm.expectRevert("The rule is already present");
+        (bool resCallBool, ) = address(ruleEngineMock).call(
+            abi.encodeCall(RuleEngine.setRules, ruleWhitelistTab)
+        );
+
+        // Assert
+        // I do not know why but the function call return true
+        // if the call is reverted with the message indicated in expectRevert
+        // assertFalse(resCallBool);
+        assertEq(resCallBool, true);
+        resUint256 = ruleEngineMock.ruleLength();
+        assertEq(resUint256, 1);
+    }
+
     function testCannotSetEmptyRulesT1() public {
         // Arrange
         IRule[] memory ruleWhitelistTab = new IRule[](0);
@@ -152,6 +176,17 @@ contract RuleEngineTest is Test, HelperContract, RuleWhitelist {
         assertEq(resUint256, 1);
     }
 
+    function testCannotAddARuleAlreadyPresent() public {
+        // Act
+        vm.expectRevert("The rule is already present");
+        vm.prank(RULE_ENGINE_OPERATOR_ADDRESS);
+        ruleEngineMock.addRule(ruleWhitelist);
+
+        // Assert
+        resUint256 = ruleEngineMock.ruleLength();
+        assertEq(resUint256, 1);
+    }
+
     function testCanRemoveWithEmptyRules() public {
         // Arrange
         vm.prank(RULE_ENGINE_OPERATOR_ADDRESS);
@@ -167,6 +202,23 @@ contract RuleEngineTest is Test, HelperContract, RuleWhitelist {
         // Assert
         resUint256 = ruleEngineMock.ruleLength();
         assertEq(resUint256, 0);
+    }
+
+    function testCanAddARuleAfterThisRuleWasRemoved() public{
+        // Arrange - Assert
+        IRule[] memory _rules = ruleEngineMock.rules();
+        assertEq(address(_rules[0]), address(ruleWhitelist));
+        
+        // Act
+        vm.prank(RULE_ENGINE_OPERATOR_ADDRESS);
+        ruleEngineMock.removeRule(ruleWhitelist);
+        
+        // Assert
+        vm.prank(RULE_ENGINE_OPERATOR_ADDRESS);
+        ruleEngineMock.addRule(ruleWhitelist);
+        _rules = ruleEngineMock.rules();
+        resUint256 = ruleEngineMock.ruleLength();
+        assertEq(resUint256, 1);
     }
 
     function testCanRemoveNonExistantRule() public {


### PR DESCRIPTION
**CVF-7**
> This function doesn't check for duplicate rules.  
> Consider adding such a check.  An efficient way to do this would be to require the "rules_" array to be sorted.  This would also simplify the zero rule test.

Fix: 
We use a hashmap to check for duplicate rules and the transaction is reverted in case of such one

**CVF-8**

> This function allows adding a duplicate rule.  
> Consider forbidding duplicate rules.

Fix: same fix as for CVF-7

**CVF-9**
```
This function removes only the first occurrence of a rule.  
Consider removing all occurrences.
```
Fix:
No longer needed since we forbid duplicate rules (CVF-7, CVF-8)