### PR TITLE
CVF-16, CVF-17: return

### DIFF
--- a/src/RuleWhiteList.sol
+++ b/src/RuleWhiteList.sol
@@ -74,10 +74,8 @@ contract RuleWhitelist is IRule, CodeList, AccessControl {
             !whitelist[_newWhitelistAddress],
             "Address is already in the whitelist"
         );
-        if (!whitelist[_newWhitelistAddress]) {
-            whitelist[_newWhitelistAddress] = true;
-            ++numAddressesWhitelisted;
-        }
+        whitelist[_newWhitelistAddress] = true;
+        ++numAddressesWhitelisted;
     }
 
     /**
@@ -92,10 +90,8 @@ contract RuleWhitelist is IRule, CodeList, AccessControl {
             whitelist[_removeWhitelistAddress],
             "Address is not in the whitelist"
         );
-        if (whitelist[_removeWhitelistAddress]) {
-            whitelist[_removeWhitelistAddress] = false;
-            --numAddressesWhitelisted;
-        }
+        whitelist[_removeWhitelistAddress] = false;
+        --numAddressesWhitelisted;
     }
 
     /**

--- a/src/RuleWhiteList.sol
+++ b/src/RuleWhiteList.sol
@@ -141,13 +141,8 @@ contract RuleWhitelist is IRule, CodeList, AccessControl {
     function canReturnTransferRestrictionCode(
         uint8 _restrictionCode
     ) external pure override returns (bool) {
-        if (
-            _restrictionCode == CODE_ADDRESS_FROM_NOT_WHITELISTED ||
-            _restrictionCode == CODE_ADDRESS_TO_NOT_WHITELISTED
-        ) {
-            return true;
-        }
-        return false;
+        return _restrictionCode == CODE_ADDRESS_FROM_NOT_WHITELISTED ||
+            _restrictionCode == CODE_ADDRESS_TO_NOT_WHITELISTED;
     }
 
     function messageForTransferRestriction(

--- a/src/RuleWhiteList.sol
+++ b/src/RuleWhiteList.sol
@@ -130,12 +130,11 @@ contract RuleWhitelist is IRule, CodeList, AccessControl {
     ) public view override returns (uint8) {
         if (!whitelist[_from]) {
             return CODE_ADDRESS_FROM_NOT_WHITELISTED;
-        }
-        if (!whitelist[_to]) {
+        }else if (!whitelist[_to]) {
             return CODE_ADDRESS_TO_NOT_WHITELISTED;
+        }else{
+            return NO_ERROR;
         }
-
-        return NO_ERROR;
     }
 
     function canReturnTransferRestrictionCode(


### PR DESCRIPTION
**CVF-16**

**CVF-17**
> This could be simplified as:
> return _restrictionCode == CODE_ADDRESS_FROM_NOT_WHITELISTED || _restrictionCode == CODE_ADDRESS_TO_NOT_WHITELISTED;

Fix: the function has been simplified as recommended