### PR TITLE
CVF-15, CVF-16, CVF-17: readibility

### DIFF
--- a/src/RuleWhiteList.sol
+++ b/src/RuleWhiteList.sol
@@ -144,13 +144,8 @@ contract RuleWhitelist is IRule, CodeList, AccessControl {
     function canReturnTransferRestrictionCode(
         uint8 _restrictionCode
     ) external pure override returns (bool) {
-        if (
-            _restrictionCode == CODE_ADDRESS_FROM_NOT_WHITELISTED ||
-            _restrictionCode == CODE_ADDRESS_TO_NOT_WHITELISTED
-        ) {
-            return true;
-        }
-        return false;
+        return _restrictionCode == CODE_ADDRESS_FROM_NOT_WHITELISTED ||
+            _restrictionCode == CODE_ADDRESS_TO_NOT_WHITELISTED;
     }
 
     function messageForTransferRestriction(

--- a/src/RuleWhiteList.sol
+++ b/src/RuleWhiteList.sol
@@ -134,12 +134,11 @@ contract RuleWhitelist is IRule, CodeList, AccessControl {
     ) public view override returns (uint8) {
         if (!whitelist[_from]) {
             return CODE_ADDRESS_FROM_NOT_WHITELISTED;
-        }
-        if (!whitelist[_to]) {
+        }else if (!whitelist[_to]) {
             return CODE_ADDRESS_TO_NOT_WHITELISTED;
+        }else{
+            return NO_ERROR;
         }
-
-        return NO_ERROR;
     }
 
     function canReturnTransferRestrictionCode(


### PR DESCRIPTION
**CVF-15**

> Should be "else if".

The function has been modified as recommended

**CVF-16**
> Should be "else return".

The function has been modified as recommended

**CVF-17**

> This could be simplified as:
return _restrictionCode == CODE_ADDRESS_FROM_NOT_WHITELISTED || _restrictionCode == CODE_ADDRESS_TO_NOT_WHITELISTED;

The function has been modified as recommended